### PR TITLE
Removing repeat and direction from timeline segment options

### DIFF
--- a/packages/dom/src/animate/types.ts
+++ b/packages/dom/src/animate/types.ts
@@ -78,7 +78,7 @@ export interface AnimationWithCommitStyles extends Animation {
 
 export type AnimationListOptions = Omit<
   AnimationOptionsWithOverrides,
-  "delay"
+  "delay" | "direction" | "repeat"
 > & {
   delay?: number | OptionResolver<number>
   at?: NextTime

--- a/packages/motion/CHANGELOG.md
+++ b/packages/motion/CHANGELOG.md
@@ -8,6 +8,10 @@ Motion One adheres to [Semantic Versioning](http://semver.org/).
 
 - [Motion One for SolidJS](https://motion.dev/solid).
 
+### Fixed
+
+- Remove `repeat` and `direction` from `timeline` segment options. [Issue (sponsors only)](https://github.com/motiondivision/motionone/issues/67)
+
 ## [10.7.2] [2022-04-16]
 
 ### Fixed


### PR DESCRIPTION
Fixes https://github.com/motiondivision/motionone/issues/67