### PR TITLE
fix @motionone/dom has no exported member named 'ViewOptions'

### DIFF
--- a/packages/solid/src/types.ts
+++ b/packages/solid/src/types.ts
@@ -2,7 +2,7 @@ import type { JSX, ParentProps } from "solid-js"
 import type {
   ValueKeyframesDefinition,
   MotionKeyframesDefinition,
-  ViewOptions,
+  InViewOptions,
 } from "@motionone/dom"
 import type { MotionEvent, CustomPointerEvent, ViewEvent } from "@motionone/dom"
 import { AnimationOptions } from "@motionone/types"
@@ -47,7 +47,7 @@ export type Options = {
   press?: VariantDefinition
   exit?: VariantDefinition
   variants?: Record<string, Variant>
-  inViewOptions?: ViewOptions
+  inViewOptions?: InViewOptions
   transition?: AnimationOptionsWithOverrides
 }
 


### PR DESCRIPTION
Fixes this error:
```sh
./node_modules/@motionone/solid/dist/types/types.d.ts:2:68 - error TS2724: '"@motionone/dom"' has no exported member named 'ViewOptions'. Did you mean 'InViewOptions'?
```