### PR TITLE
fix: let on exit animations work with solid 1.5.0

### DIFF
--- a/packages/solid/src/presence.tsx
+++ b/packages/solid/src/presence.tsx
@@ -89,13 +89,12 @@ export const Presence: FlowComponent<{
               batch(() => {
                 // exit -> enter
                 if (props.exitBeforeEnter) {
-                  setEl()
                   exitTransition(() => !exiting && enterTransition(newEl))
                 }
                 // exit & enter
                 else {
-                  enterTransition(newEl)
                   exitTransition()
+                  enterTransition(newEl)
                 }
               })
             })


### PR DESCRIPTION
This closes issue #135. Thanks to both @vxncetxn and @mdynnl