### PR TITLE
Add linear and cubic-bezier functions to easing type

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -63,6 +63,7 @@ export type Easing =
   | "steps-start"
   | "steps-end"
   | `steps(${number}, ${"start" | "end"})`
+  | `cubic-bezier(${string})`
   | BezierDefinition
 
 export type EasingGenerator = {


### PR DESCRIPTION
Adds the native `linear` and `cubic-bezier` functions. These seem to work fine but the types complain. I know i could specify this as a function but i am pulling the easing from common themes that are used in CSS as well as JS

Admittedly this is a GH editor drive by, apologies if CI hates it i can fixup. 