### PR TITLE
Fix typo from easing functions (step-start/step-end)

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -162,8 +162,8 @@ export type Easing =
   | "ease-in"
   | "ease-out"
   | "ease-in-out"
-  | "steps-start"
-  | "steps-end"
+  | "step-start"
+  | "step-end"
   | `steps(${number}, ${"start" | "end"})`
   | BezierDefinition
 


### PR DESCRIPTION
According to MDN, it should be step-start([1][]) and step-end([2][]) instead of step"s"-start and step"s"-end

[1]: https://developer.mozilla.org/en-US/docs/Web/CSS/animation-timing-function#step-start
[2]: https://developer.mozilla.org/en-US/docs/Web/CSS/animation-timing-function#step-end