### PR TITLE
fix: When update state types as string, target style can't be correct…

### DIFF
--- a/packages/dom/src/state/index.ts
+++ b/packages/dom/src/state/index.ts
@@ -116,7 +116,8 @@ export function createMotionState(
       if (!activeStates[name as keyof typeof activeStates]) continue
 
       const variant = resolveVariant(
-        options[name as keyof typeof options] as any
+        options[name as keyof typeof options] as any,
+        options.variants
       )
 
       if (!variant) continue


### PR DESCRIPTION
When update state types as string, target style can't be correctly resolved by variants
Need to add the second parameter of the resolveVariant function